### PR TITLE
Post

### DIFF
--- a/fintech_zerobase/src/main/java/com/example/fintech_zerobase/controller/MemberController.java
+++ b/fintech_zerobase/src/main/java/com/example/fintech_zerobase/controller/MemberController.java
@@ -27,11 +27,14 @@ public class MemberController {
     }
 
     @PostMapping("/save")
+    /*
+    데이터 저장의 경우 body에 담아서, 검색 조건은 param
+     */
     public String save(
-            @RequestParam("id") Long id,
-            @RequestParam("name") String name,
-            @RequestParam("password") String password,
-            @RequestParam("age") int age,
+            @RequestBody Long id,
+             String name,
+             String password,
+             int age,
             Model model){
         Member member = new Member(id, name, password, age);
         memberRepository.save(member);

--- a/fintech_zerobase/src/main/java/com/example/fintech_zerobase/controller/MemberController.java
+++ b/fintech_zerobase/src/main/java/com/example/fintech_zerobase/controller/MemberController.java
@@ -3,23 +3,20 @@ package com.example.fintech_zerobase.controller;
 import com.example.fintech_zerobase.domain.Member;
 import com.example.fintech_zerobase.repository.MemoryMemberRepository;
 import com.example.fintech_zerobase.service.MemberServiceImpl;
-import jakarta.annotation.PostConstruct;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.DeleteMapping;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.ui.Model;
+import org.springframework.web.bind.annotation.*;
 
-import java.util.Optional;
+import java.util.List;
 
-@RestController
+@RestController("/members")
 @RequiredArgsConstructor
 public class MemberController {
     private MemoryMemberRepository memberRepository;
     private MemberServiceImpl memberService;
 
-    @GetMapping("/members/{id}")
+    @GetMapping("/form")
     public ResponseEntity<String> findMember(@PathVariable("id") Long id){
         Member member = memberRepository.findById(id);
         if (member != null){
@@ -29,9 +26,25 @@ public class MemberController {
         }
     }
 
-    @PostConstruct
-    public void save(){
-        memberRepository.save(new Member());
+    @PostMapping("/save")
+    public String save(
+            @RequestParam("id") Long id,
+            @RequestParam("name") String name,
+            @RequestParam("password") String password,
+            @RequestParam("age") int age,
+            Model model){
+        Member member = new Member(id, name, password, age);
+        memberRepository.save(member);
+
+        model.addAttribute("member", member);
+        return "save";
+    }
+
+    @GetMapping
+    public String members(Model model) {
+        List<Member> members = memberRepository.findAll();
+        model.addAttribute("members", members);
+        return "members";
     }
 
     @DeleteMapping

--- a/fintech_zerobase/src/main/java/com/example/fintech_zerobase/domain/Account.java
+++ b/fintech_zerobase/src/main/java/com/example/fintech_zerobase/domain/Account.java
@@ -1,5 +1,6 @@
 package com.example.fintech_zerobase.domain;
 
+import com.example.fintech_zerobase.type.AccountStatus;
 import jakarta.persistence.*;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
@@ -17,8 +18,13 @@ public class Account {
 
     @Id @GeneratedValue(strategy = GenerationType.AUTO)
     private Long id;
-
+    private String accountNumber;
     private Long balance;
     private LocalDateTime registeredAt;
     private LocalDateTime unregisteredAt;
+
+    private Member member;
+
+    @Enumerated(EnumType.STRING)
+    private AccountStatus accountStatus;
 }

--- a/fintech_zerobase/src/main/java/com/example/fintech_zerobase/domain/Account.java
+++ b/fintech_zerobase/src/main/java/com/example/fintech_zerobase/domain/Account.java
@@ -14,16 +14,15 @@ import java.util.List;
 @Setter
 @RequiredArgsConstructor
 @Entity
-public class Account {
+public class Account extends BaseEntity{
 
     @Id @GeneratedValue(strategy = GenerationType.AUTO)
     private Long id;
     private String accountNumber;
     private Long balance;
-    private LocalDateTime registeredAt;
-    private LocalDateTime unregisteredAt;
 
-    private Member member;
+    @OneToMany(mappedBy = "account")
+    private List<Member> members = new ArrayList<>();
 
     @Enumerated(EnumType.STRING)
     private AccountStatus accountStatus;

--- a/fintech_zerobase/src/main/java/com/example/fintech_zerobase/domain/BaseEntity.java
+++ b/fintech_zerobase/src/main/java/com/example/fintech_zerobase/domain/BaseEntity.java
@@ -1,0 +1,27 @@
+package com.example.fintech_zerobase.domain;
+
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
+import jakarta.persistence.Temporal;
+import jakarta.persistence.TemporalType;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener.class)
+public class BaseEntity {
+    @Temporal(TemporalType.TIMESTAMP)
+    private LocalDateTime registeredAt;
+    @Temporal(TemporalType.TIMESTAMP)
+    private LocalDateTime unregisteredAt;
+}

--- a/fintech_zerobase/src/main/java/com/example/fintech_zerobase/domain/Member.java
+++ b/fintech_zerobase/src/main/java/com/example/fintech_zerobase/domain/Member.java
@@ -26,6 +26,13 @@ public class Member {
     @Enumerated(EnumType.STRING)
     private Grade grade;
 
+    public Member(Long id, String name, String password, int age) {
+        this.id = id;
+        this.name = name;
+        this.password = password;
+        this.age = age;
+    }
+
     public int check_Age(int age){
         if (age < 18) {
             System.out.println("부모의 동의가 필요 합니다.");

--- a/fintech_zerobase/src/main/java/com/example/fintech_zerobase/domain/Member.java
+++ b/fintech_zerobase/src/main/java/com/example/fintech_zerobase/domain/Member.java
@@ -8,7 +8,7 @@ import lombok.Setter;
 @Entity
 @Getter
 @Setter
-public class Member {
+public class Member extends BaseEntity{
 
     @Id @GeneratedValue(strategy = GenerationType.AUTO)
     private Long id;

--- a/fintech_zerobase/src/main/java/com/example/fintech_zerobase/dto/AccountDto.java
+++ b/fintech_zerobase/src/main/java/com/example/fintech_zerobase/dto/AccountDto.java
@@ -16,6 +16,7 @@ public class AccountDto {
     private Long id;
     private String bankName;
     private String password;
+    private String balance;
     private String accountNumber;
     private Long account_amount;
     private AccountStatus accountStatus;

--- a/fintech_zerobase/src/main/java/com/example/fintech_zerobase/dto/AccountInfo.java
+++ b/fintech_zerobase/src/main/java/com/example/fintech_zerobase/dto/AccountInfo.java
@@ -1,0 +1,12 @@
+package com.example.fintech_zerobase.dto;
+
+import com.example.fintech_zerobase.type.AccountStatus;
+import lombok.Data;
+
+@Data
+public class AccountInfo {
+    private String accountNumber;
+    private String accountPassword;
+    private int account_amount;
+    private AccountStatus accountStatus;
+}

--- a/fintech_zerobase/src/main/java/com/example/fintech_zerobase/dto/CancelAccountDto.java
+++ b/fintech_zerobase/src/main/java/com/example/fintech_zerobase/dto/CancelAccountDto.java
@@ -1,0 +1,21 @@
+package com.example.fintech_zerobase.dto;
+
+import lombok.Getter;
+import lombok.Setter;
+import java.time.LocalDateTime;
+
+@Getter
+@Setter
+public class CancelAccountDto {
+
+    private int amount;
+    private LocalDateTime requestDate;
+    private String accountNumber;
+
+
+    public CancelAccountDto(int amount, LocalDateTime requestDate, String accountNumber) {
+        this.amount = amount;
+        this.requestDate = requestDate;
+        this.accountNumber = accountNumber;
+    }
+}

--- a/fintech_zerobase/src/main/java/com/example/fintech_zerobase/dto/CreateAccountDto.java
+++ b/fintech_zerobase/src/main/java/com/example/fintech_zerobase/dto/CreateAccountDto.java
@@ -1,0 +1,42 @@
+package com.example.fintech_zerobase.dto;
+
+import lombok.*;
+import org.antlr.v4.runtime.misc.NotNull;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+
+public class CreateAccountDto {
+
+    @Data
+    public static class Request {
+
+        @NotNull
+        private long userId;
+
+        @NotNull
+        private String init;
+    }
+
+    @Getter
+    @Setter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Builder
+    public static class Response{
+        private Long userId;
+        private String accountNumber;
+        private LocalDateTime registeredAt;
+
+        public static Response from(AccountDto accountDto){
+            return Response.builder()
+                    .userId(accountDto.getId())
+                    .accountNumber(accountDto.getAccountNumber())
+                    .registeredAt(accountDto.getCreatedAt())
+                    .build();
+        }
+    }
+
+
+}

--- a/fintech_zerobase/src/main/java/com/example/fintech_zerobase/dto/DeleteAccountDto.java
+++ b/fintech_zerobase/src/main/java/com/example/fintech_zerobase/dto/DeleteAccountDto.java
@@ -1,0 +1,14 @@
+package com.example.fintech_zerobase.dto;
+
+import lombok.Data;
+
+import java.io.IOException;
+import java.time.LocalDateTime;
+
+@Data
+public class DeleteAccountDto {
+
+    private Long userId;
+    private String accountNumber;
+    private LocalDateTime unRegisteredAt;
+}

--- a/fintech_zerobase/src/main/java/com/example/fintech_zerobase/dto/ErrorResponse.java
+++ b/fintech_zerobase/src/main/java/com/example/fintech_zerobase/dto/ErrorResponse.java
@@ -1,0 +1,26 @@
+package com.example.fintech_zerobase.dto;
+
+import com.example.fintech_zerobase.type.ErrorCode;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class ErrorResponse {
+    private ErrorCode errorCode;
+    private String errorMessage;
+
+    public static ResponseEntity<ErrorResponse> toResponse(ErrorCode errorCode){
+        ErrorResponse errorResponse = ErrorResponse.builder()
+                .errorCode(errorCode)
+                .errorMessage(errorCode.getGetMessage())
+                .build();
+        return new ResponseEntity<>(errorResponse, HttpStatus.BAD_REQUEST);
+    }
+}

--- a/fintech_zerobase/src/main/java/com/example/fintech_zerobase/exception/AccountException.java
+++ b/fintech_zerobase/src/main/java/com/example/fintech_zerobase/exception/AccountException.java
@@ -1,0 +1,22 @@
+package com.example.fintech_zerobase.exception;
+
+import com.example.fintech_zerobase.type.ErrorCode;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@RequiredArgsConstructor
+@Builder
+public class AccountException extends RuntimeException {
+
+    private ErrorCode errorCode;
+    private String errorMessage;
+
+    public AccountException(ErrorCode errorCode){
+        this.errorCode = errorCode;
+        this.errorMessage = errorCode.getText();
+    }
+}

--- a/fintech_zerobase/src/main/java/com/example/fintech_zerobase/exception/AccountException.java
+++ b/fintech_zerobase/src/main/java/com/example/fintech_zerobase/exception/AccountException.java
@@ -1,22 +1,17 @@
 package com.example.fintech_zerobase.exception;
 
 import com.example.fintech_zerobase.type.ErrorCode;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.RequiredArgsConstructor;
-import lombok.Setter;
+import lombok.*;
 
 @Getter
 @Setter
-@RequiredArgsConstructor
+@NoArgsConstructor
+@AllArgsConstructor
 @Builder
 public class AccountException extends RuntimeException {
 
     private ErrorCode errorCode;
     private String errorMessage;
 
-    public AccountException(ErrorCode errorCode){
-        this.errorCode = errorCode;
-        this.errorMessage = errorCode.getText();
-    }
+
 }

--- a/fintech_zerobase/src/main/java/com/example/fintech_zerobase/exception/GlobalExceptionHandler.java
+++ b/fintech_zerobase/src/main/java/com/example/fintech_zerobase/exception/GlobalExceptionHandler.java
@@ -1,0 +1,19 @@
+package com.example.fintech_zerobase.exception;
+
+import com.example.fintech_zerobase.dto.ErrorResponse;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@Slf4j
+public class GlobalExceptionHandler {
+
+    @ExceptionHandler(AccountException.class)
+    //발생한 특정 예외를 잡아서 하나의 메소드에서 공통 처리
+    public ResponseEntity<ErrorResponse> handelAccountException(AccountException ex){
+        log.error("handelAccountException");
+       return ErrorResponse.toResponse(ex.getErrorCode());
+    }
+}

--- a/fintech_zerobase/src/main/java/com/example/fintech_zerobase/repository/AccountRepository.java
+++ b/fintech_zerobase/src/main/java/com/example/fintech_zerobase/repository/AccountRepository.java
@@ -5,12 +5,13 @@ import com.example.fintech_zerobase.domain.Member;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;
+import java.util.Optional;
 
 public interface AccountRepository extends JpaRepository<Account, Long> {
 
     Integer countAccount(Member member);
 
-    Account findByInfo(String accountNumber);
+    Optional<Account> findByInfo(String accountNumber);
 
     List<Account> findAllAccount(Member member);
 }

--- a/fintech_zerobase/src/main/java/com/example/fintech_zerobase/repository/AccountRepository.java
+++ b/fintech_zerobase/src/main/java/com/example/fintech_zerobase/repository/AccountRepository.java
@@ -1,0 +1,16 @@
+package com.example.fintech_zerobase.repository;
+
+import com.example.fintech_zerobase.domain.Account;
+import com.example.fintech_zerobase.domain.Member;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface AccountRepository extends JpaRepository<Account, Long> {
+
+    Integer countAccount(Member member);
+
+    Account findByInfo(String accountNumber);
+
+    List<Account> findAllAccount(Member member);
+}

--- a/fintech_zerobase/src/main/java/com/example/fintech_zerobase/service/AccountService.java
+++ b/fintech_zerobase/src/main/java/com/example/fintech_zerobase/service/AccountService.java
@@ -1,0 +1,13 @@
+package com.example.fintech_zerobase.service;
+
+import com.example.fintech_zerobase.dto.AccountDto;
+
+import java.util.List;
+
+public interface AccountService {
+    AccountDto createAccount(Long id, Long balance);
+
+    AccountDto deleteAccount(Long id, String name, String password, String accountNumber);
+
+    List<AccountDto> findAllAccount(Long id);
+}

--- a/fintech_zerobase/src/main/java/com/example/fintech_zerobase/service/AccountServiceImpl.java
+++ b/fintech_zerobase/src/main/java/com/example/fintech_zerobase/service/AccountServiceImpl.java
@@ -1,0 +1,116 @@
+package com.example.fintech_zerobase.service;
+
+import com.example.fintech_zerobase.domain.Account;
+import com.example.fintech_zerobase.domain.Member;
+import com.example.fintech_zerobase.dto.AccountDto;
+import com.example.fintech_zerobase.repository.AccountRepository;
+import com.example.fintech_zerobase.repository.MemberRepository;
+import com.example.fintech_zerobase.repository.MemoryMemberRepository;
+import com.example.fintech_zerobase.type.AccountStatus;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+
+
+@Service
+@RequiredArgsConstructor
+public class AccountServiceImpl implements AccountService{
+
+    @Autowired
+    private final AccountRepository accountRepository;
+    @Autowired
+    private final MemberRepository memberRepository;
+
+
+    @Override
+    public AccountDto createAccount(Long id, Long balance) {
+        Member member = getAccountMember(id);
+
+        validateCreateAccount(member);
+
+        //본인인증 ??
+
+        Account account = new Account();
+        account.setId(1L);
+        account.setBalance(balance);
+        accountRepository.save(account);
+        return accountDto(account);
+    }
+
+    @Override
+    public AccountDto deleteAccount(Long id, String name, String password, String accountNumber) {
+        Member member = getAccountMember(id);
+
+        Account account = accountRepository.findByInfo(accountNumber);
+
+        validateDeleteAccount(member, account);
+
+        account.setAccountStatus(AccountStatus.UN_REGISTERED);
+        accountRepository.save(account);
+        return accountDto(account);
+    }
+
+    @Override
+    public List<AccountDto> findAllAccount(Long id) {
+       Member member = getAccountMember(id);
+
+       List<Account> accounts = accountRepository.findAllAccount(member);
+
+       return accountDtoList(accounts);
+    }
+
+    private List<AccountDto> accountDtoList(List<Account> accounts) {
+        List<AccountDto> accountDtoList = new ArrayList<>();
+        for (AccountDto account : accountDtoList) {
+            AccountDto accountDto = new AccountDto();
+            accountDto.setId(account.getId());
+            accountDto.setBalance(account.getBalance());
+            accountDtoList.add(accountDto);
+        }
+
+        return accountDtoList;
+    }
+
+    private void validateDeleteAccount(Member member, Account account) {
+        if (!Objects.equals(member.getId(), account.getMember().getId())){
+            throw new RuntimeException("아이디가 맞지 않습니다.");
+        }
+
+        if (account.getAccountStatus() == AccountStatus.UN_REGISTERED){
+            throw new RuntimeException("이미 해지된 계좌 입니다");
+        }
+
+        if (account.getBalance() != 0){
+            throw new RuntimeException("잔고를 비워주세요");
+        }
+
+        //비밀번호 유효성 검사 추가
+    }
+
+    private AccountDto accountDto(Account account) {
+        AccountDto accountDto = new AccountDto();
+        accountDto.setId(account.getId());
+        accountDto.setBalance(accountDto.getBalance());
+        return accountDto;
+    }
+
+    private void validateCreateAccount(Member member) {
+        if (accountRepository.countAccount(member) >= 10) {
+            throw new RuntimeException("만들수 있는 계좌 수를 초과 했습니다.");
+        }
+
+        if (member.check_Age(member.getAge()) < 18){
+            throw new RuntimeException("미성년자는 부모님의 동의가 있어야 계좌 생성이 가능합니다.");
+        }
+    }
+
+    private Member getAccountMember(Long id) {
+       return memberRepository.findById(id)
+               .orElseThrow(() -> new RuntimeException("회원을 찾지 못했습니다."));
+    }
+
+}

--- a/fintech_zerobase/src/main/java/com/example/fintech_zerobase/service/MemberServiceImpl.java
+++ b/fintech_zerobase/src/main/java/com/example/fintech_zerobase/service/MemberServiceImpl.java
@@ -1,7 +1,6 @@
 package com.example.fintech_zerobase.service;
 
 import com.example.fintech_zerobase.domain.Member;
-import com.example.fintech_zerobase.repository.MemberRepository;
 import com.example.fintech_zerobase.repository.MemoryMemberRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;

--- a/fintech_zerobase/src/main/java/com/example/fintech_zerobase/servlet/CancelAccountDtoServlet.java
+++ b/fintech_zerobase/src/main/java/com/example/fintech_zerobase/servlet/CancelAccountDtoServlet.java
@@ -1,0 +1,36 @@
+package com.example.fintech_zerobase.servlet;
+
+import com.example.fintech_zerobase.dto.CancelAccountDto;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.annotation.WebServlet;
+import jakarta.servlet.http.HttpServlet;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+
+import java.io.IOException;
+
+import static jakarta.servlet.http.HttpServletResponse.SC_BAD_REQUEST;
+import static jakarta.servlet.http.HttpServletResponse.SC_OK;
+
+@WebServlet("/cancelBalanceServlet")
+public class CancelAccountDtoServlet extends HttpServlet {
+    @Override
+    protected void service(HttpServletRequest request, HttpServletResponse response) throws ServletException, IOException {
+        response.setContentType("application/json");
+
+        ObjectMapper mapper = new ObjectMapper();
+
+        try {
+            CancelAccountDto cancelBalanceDto = mapper.readValue(request.getInputStream(), CancelAccountDto.class);
+            System.out.println("CancelBalanceServlet.service");
+
+            response.setStatus(SC_OK);
+            mapper.writeValue(response.getWriter(), cancelBalanceDto);
+        } catch (Exception e){
+            response.setStatus((SC_BAD_REQUEST));
+            response.getWriter().write("잘못된 접근 입니다.");
+            e.printStackTrace();
+        }
+    }
+}

--- a/fintech_zerobase/src/main/java/com/example/fintech_zerobase/servlet/DeleteAccountDtoServlet.java
+++ b/fintech_zerobase/src/main/java/com/example/fintech_zerobase/servlet/DeleteAccountDtoServlet.java
@@ -1,0 +1,33 @@
+package com.example.fintech_zerobase.servlet;
+
+import com.example.fintech_zerobase.dto.DeleteAccountDto;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.annotation.WebServlet;
+import jakarta.servlet.http.HttpServlet;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+
+import java.io.IOException;
+
+@WebServlet("/deleteAccountDtoServlet")
+public class DeleteAccountDtoServlet extends HttpServlet {
+    @Override
+    protected void service(HttpServletRequest request, HttpServletResponse response) throws ServletException, IOException {
+        response.setContentType("application/json");
+        ObjectMapper mapper = new ObjectMapper();
+
+        try{
+            DeleteAccountDto deleteAccountDto = mapper.readValue(request.getInputStream(), DeleteAccountDto.class);
+
+            System.out.println("DeleteAccountDtoServlet.service");
+
+            response.setStatus(HttpServletResponse.SC_OK);
+            mapper.writeValue(response.getWriter(), deleteAccountDto);
+        } catch (Exception e) {
+            response.setStatus(HttpServletResponse.SC_BAD_REQUEST);
+            response.getWriter().write("잘못된 접근입니다.");
+            e.printStackTrace();
+        }
+    }
+}

--- a/fintech_zerobase/src/main/java/com/example/fintech_zerobase/type/ErrorCode.java
+++ b/fintech_zerobase/src/main/java/com/example/fintech_zerobase/type/ErrorCode.java
@@ -1,0 +1,13 @@
+package com.example.fintech_zerobase.type;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@AllArgsConstructor
+public enum ErrorCode {
+    USER_NOT_FOUND("사용자가 없습니다.");
+
+    private final String getText;
+}

--- a/fintech_zerobase/src/main/java/com/example/fintech_zerobase/type/ErrorCode.java
+++ b/fintech_zerobase/src/main/java/com/example/fintech_zerobase/type/ErrorCode.java
@@ -5,9 +5,12 @@ import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 
 @Getter
-@AllArgsConstructor
+@RequiredArgsConstructor
 public enum ErrorCode {
-    USER_NOT_FOUND("사용자가 없습니다.");
-
-    private final String getText;
+    USER_NOT_FOUND("사용자가 없습니다."),
+    USER_UN_MATCH("사용자가 맞지 않습니다."),
+    EMPTY_YOUR_BALANCE("잔고를 비워주세요"),
+    TOO_MUCH_ACCOUNT("생성된 계좌가 너무 많습니다"),
+    TOO_YOUNG_TO_CREATE_BALANCE("너무 어려서 만들 수 없습니다.");
+    private final String getMessage;
 }

--- a/fintech_zerobase/src/test/java/com/example/fintech_zerobase/service/MemberServiceImplTest.java
+++ b/fintech_zerobase/src/test/java/com/example/fintech_zerobase/service/MemberServiceImplTest.java
@@ -18,8 +18,7 @@ class MemberServiceImplTest {
     @Test
         void join(){
         //given
-        Member member = new Member();
-        member.setId(1L);
+        Member member = new Member(1L, "황", "1234", 25);
         //when
         memberService.join(member);
         Member findMember = memberService.findMember(1L);


### PR DESCRIPTION
# Feature 3
###  계좌 생성 삭제 조회 기능을 생성 (아직 test 코드 작성 하지 못함) 
생성시 계좌 개수에 생성 제한을 두었고,  소유주가 다르거나, 미성년자 일 경우 만들 수 없도록 제한을 두었습니다. 

삭제시에는 좀더 많은 검증을 통해 제한을 두려고 했습니다
password 인증을 통해 검증을 하고 싶지만 어떡해 시작을 해야 할지 몰라 시작을 못하고 있습니다. 

예외는 추후에 따로 처리 할 예정입니다. 아직은 RuntimeException으로 예외를 날리도록 했습니다. 

### Account & Member 
계좌 생성 조회 삭제 기능을 구현하는 도중에 일부 필요한 내용이 있어 추가했습니다. 

### MemberController를 좀더 쉽게 구현하도록 변경해 보았습니다. 

어떤 변경 사항이 있었나요?? 
[ 0 ] 기능 개발 구현 및 변경 
[ x ] 테스트 구현 및 변경 

